### PR TITLE
Nested Splits

### DIFF
--- a/lib/sitehub/collection/route_collection.rb
+++ b/lib/sitehub/collection/route_collection.rb
@@ -18,7 +18,7 @@ class SiteHub
       end
 
       def transform &block
-        each  do |id, value|
+        each do |id, value|
           self[id] = block.call(value)
         end
       end

--- a/lib/sitehub/collection/split_route_collection.rb
+++ b/lib/sitehub/collection/split_route_collection.rb
@@ -24,7 +24,7 @@ class SiteHub
       def resolve(*args)
         random = rand(100)
         result = values.find { |split| random >= split.lower && random < split.upper }
-        result ? result.value : nil
+        result ? result.value.resolve(*args) : nil
       end
 
       def transform &block

--- a/lib/sitehub/forward_proxy_builder.rb
+++ b/lib/sitehub/forward_proxy_builder.rb
@@ -42,9 +42,18 @@ class SiteHub
       @endpoints = collection
     end
 
-    def split(percentage:, url:, label:, &block)
+    def split(percentage:, url:nil, label:nil, &block)
       endpoints(splits)
-      endpoints.add label.to_sym, forward_proxy(label: label, url: url), percentage
+
+      if block
+        builder = self.class.new(mapped_path: mapped_path, &block).build
+        endpoints.add UUID.generate(:compact), builder, percentage
+      else
+        parameters = [url, label]
+        raise InvalidDefinitionException, "label and url must be defined if not supplying a block" unless parameters.all?
+        endpoints.add label.to_sym, forward_proxy(label: label, url: url), percentage
+      end
+
     end
 
     def route url:nil, label:nil, rule: nil, &block

--- a/spec/support/shared_contexts/sitehub_context.rb
+++ b/spec/support/shared_contexts/sitehub_context.rb
@@ -11,7 +11,13 @@ shared_context :site_hub do
     SiteHub::Builder.new.tap do |builder|
       builder.access_logger StringIO.new
       builder.error_logger StringIO.new
-      builder.proxy "/endpoint" => downstream_url
+      downstream_url = downstream_url()
+      builder.proxy "/endpoint" do
+        split(percentage: 100) do
+          split percentage: 50, label: 'experiment1', url: downstream_url
+          split percentage: 50, label: 'experiment2', url: downstream_url
+        end
+      end
     end
   end
 


### PR DESCRIPTION
splits can now behave like routes and can have routes or splits nested within them.

E.g.

``` ruby
SiteHub.build do
  split(percentage: 100) do
    # Code for splits or routes
  end
end
```
